### PR TITLE
Video and message events must be strictly synchronious

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 /vendor/
 composer.lock
+/nbproject/

--- a/src/Events/NewConversationCreated.php
+++ b/src/Events/NewConversationCreated.php
@@ -5,11 +5,11 @@ namespace PhpJunior\LaravelVideoChat\Events;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class NewConversationCreated implements ShouldBroadcast
+class NewConversationCreated implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/src/Events/NewConversationMessage.php
+++ b/src/Events/NewConversationMessage.php
@@ -5,11 +5,11 @@ namespace PhpJunior\LaravelVideoChat\Events;
 use Carbon\Carbon;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class NewConversationMessage implements ShouldBroadcast
+class NewConversationMessage implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
     /**

--- a/src/Events/NewGroupConversationMessage.php
+++ b/src/Events/NewGroupConversationMessage.php
@@ -5,11 +5,11 @@ namespace PhpJunior\LaravelVideoChat\Events;
 use Carbon\Carbon;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class NewGroupConversationMessage implements ShouldBroadcast
+class NewGroupConversationMessage implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/src/Events/VideoChatStart.php
+++ b/src/Events/VideoChatStart.php
@@ -4,11 +4,11 @@ namespace PhpJunior\LaravelVideoChat\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PresenceChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class VideoChatStart implements ShouldBroadcast
+class VideoChatStart implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 


### PR DESCRIPTION
In the base package it assumed that queue driver will be **sync**. If I use **redis** driver, neither messages nor videocall works, instead laravel queue driver becomes overloaded. I solved the problem by making events synchronious